### PR TITLE
Remove needless quotes

### DIFF
--- a/sidekick.el
+++ b/sidekick.el
@@ -65,8 +65,8 @@
 (defcustom sidekick-window-side 'right
     "The Sidekick window position, left or right."
     :type '(choice
-               (const :tag "Left" 'left)
-               (const :tag "Right" 'right)))
+               (const :tag "Left" left)
+               (const :tag "Right" right)))
 
 (defcustom sidekick-window-hide-footer nil
     "Remove the Sidekick footer branding."


### PR DESCRIPTION
Newer development emacs generates the following warning. This patch fixes it.

```
sidekick.el:65:12: Warning: defcustom for ‘sidekick-window-side’ has
    syntactically odd type ‘'(choice (const :tag Left 'left) (const :tag Right
    'right))’
```