### PR TITLE
feat: Evil integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ example:
 (global-set-key (kbd "C-c C-k") 'sidekick-search-for-literal)
 ```
 
+#### Evil
+
+[Evil-mode](https://github.com/emacs-evil/evil) integration is provided by `sidekick-evil`.
+Load it with:
+
+``` emacs-lisp
+(with-eval-after-load 'sidekick
+    (require 'sidekick-evil))
+```
+
+##### Evil Bindings
+
+| Key   | Command                          | Description                                              |
+|-------|----------------------------------|----------------------------------------------------------|
+| `q`   | **sidekick-quit**                | Closes the Sidekick window and kills it's buffer.        |
+| `g`   | **sidekick-refresh**             | Re-runs the previous operations, refreshing the results. |
+| `n`   | **sidekick-open-next-match**     | Displays the next match.                                 |
+| `N`   | **sidekick-open-previous-match** | Displays the previous match.                             |
+| `RET` | **sidekick-open-match**          | Go's directly to the matched symbol.                     |
+
 ## Configuration
 
 #### How the projects root directory is determined

--- a/extra/sidekick-evil.el
+++ b/extra/sidekick-evil.el
@@ -1,0 +1,39 @@
+;;; sidekick-evil.el --- Description -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2022 Aryslan Yakshibaev
+;;
+;; Author: Aryslan Yakshibaev <yak.aryslan.1999@gmail.com>
+;; Maintainer: Aryslan Yakshibaev <yak.aryslan.1999@gmail.com>
+;; Created: June 26, 2022
+;; Modified: June 26, 2022
+;; Version: 0.0.1
+;; Keywords: abbrev bib c calendar comm convenience data docs emulations extensions faces files frames games hardware help hypermedia i18n internal languages lisp local maint mail matching mouse multimedia news outlines processes terminals tex tools unix vc wp
+;; Homepage: https://github.com/Consoleaf/sidekick-evil
+;; Package-Requires: ((emacs "24.3"))
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;;  Description
+;;
+;;; Code:
+
+(require 'evil)
+(require 'sidekick)
+
+(evil-define-state sidekick
+  "Sidekick state"
+  :cursor 'box
+  :enable (motion))
+
+(evil-set-initial-state 'sidekick-mode 'sidekick)
+
+(define-key evil-sidekick-state-map (kbd "q") #'sidekick-quit)
+(define-key evil-sidekick-state-map "g" #'sidekick-refresh)
+(define-key evil-sidekick-state-map "n" #'sidekick-open-next-match)
+(define-key evil-sidekick-state-map "N" #'sidekick-open-previous-match)
+(define-key evil-sidekick-state-map (kbd "RET") #'sidekick-open-match)
+
+(provide 'sidekick-evil)
+;;; sidekick-evil.el ends here

--- a/extra/sidekick-evil.el
+++ b/extra/sidekick-evil.el
@@ -7,15 +7,15 @@
 ;; Created: June 26, 2022
 ;; Modified: June 26, 2022
 ;; Version: 0.0.1
-;; Keywords: abbrev bib c calendar comm convenience data docs emulations extensions faces files frames games hardware help hypermedia i18n internal languages lisp local maint mail matching mouse multimedia news outlines processes terminals tex tools unix vc wp
-;; Homepage: https://github.com/Consoleaf/sidekick-evil
+;; Keywords: extensions, lisp, evil
+;; Homepage: https://github.com/VernonGrant/sidekick.el
 ;; Package-Requires: ((emacs "24.3"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; Commentary:
 ;;
-;;  Description
+;;  `sidekick-evil' provides integration for `sidekick' with `evil-mode'
 ;;
 ;;; Code:
 


### PR DESCRIPTION
Due to how [Evil](https://github.com/emacs-evil/evil) works, keys like `n` and `p` don't work out of the box with it active.

This PR "evil-ifies" Sidekick to work with Evil. 

Replaced (only for Evil) `p` with `N` to conform to Vim conventions.
